### PR TITLE
URL updates, including fix for chef-full template 404 error

### DIFF
--- a/recipes/bootstrap_template.rb
+++ b/recipes/bootstrap_template.rb
@@ -24,7 +24,7 @@ include_recipe 'pxe_dust::installers'
 
 #write out a new pxedust.erb template
 remote_file "#{node['pxe_dust']['dir']}/chef-full.erb" do
-  source "https://raw.github.com/opscode/chef/master/lib/chef/knife/bootstrap/chef-full.erb"
+  source "https://raw.githubusercontent.com/chef/chef/master/lib/chef/knife/bootstrap/templates/chef-full.erb"
 end
 
 # change URL from

--- a/recipes/bootstrap_template.rb
+++ b/recipes/bootstrap_template.rb
@@ -28,12 +28,12 @@ remote_file "#{node['pxe_dust']['dir']}/chef-full.erb" do
 end
 
 # change URL from
-# url="http://www.opscode.com/chef/download?v=${version}&p=${platform}&pv=${platform_version}&m=${machine}"
+# url="http://www.chef.io/chef/download?v=${version}&p=${platform}&pv=${platform_version}&m=${machine}"
 # to
 # url="http://hypnotoad/${platform}-${platform_version}-${machine}/${filename}"
 ruby_block "template url" do
   block do
-    sed = "sed 's/https:\\/\\/www.opscode.com\\/chef\\//"
+    sed = "sed 's/https:\\/\\/www.chef.io\\/chef\\//"
     sed += "http:\\/\\/#{node['ipaddress']}\\/#{node['hostname']}-/'"
     sed += " #{node['pxe_dust']['dir']}/chef-full.erb"
     Chef::Log.debug sed
@@ -50,16 +50,16 @@ end
 
 #write out a new install.sh
 remote_file "#{node['pxe_dust']['dir']}/original-install.sh" do
-  source "https://opscode.com/chef/install.sh"
+  source "https://chef.io/chef/install.sh"
 end
 
 # change URL from
-# url="http://www.opscode.com/chef/download?v=${version}&p=${platform}&pv=${platform_version}&m=${machine}"
+# url="http://www.chef.io/chef/download?v=${version}&p=${platform}&pv=${platform_version}&m=${machine}"
 # to
 # url="http://hypnotoad/opscode-full-stack/${platform}-${platform_version}-${machine}/${filename}"
 ruby_block "install.sh url" do
   block do
-    sed = "sed 's/https:\\/\\/opscode.com\\/chef\\/download?v=${version}&prerelease=${prerelease}&p=${platform}&pv=${platform_version}&m=${machine}/"
+    sed = "sed 's/https:\\/\\/chef.io\\/chef\\/download?v=${version}&prerelease=${prerelease}&p=${platform}&pv=${platform_version}&m=${machine}/"
     sed += "http:\\/\\/#{node['ipaddress']}\\/opscode-full-stack\\/${platform}-${platform_version}-${machine}\\/${filename}/'"
     sed += " #{node['pxe_dust']['dir']}/original-install.sh"
     Chef::Log.debug sed

--- a/recipes/installers.rb
+++ b/recipes/installers.rb
@@ -83,7 +83,7 @@ pxe_dust.each do |id|
     installer = "chef_#{node['pxe_dust']['chefversion']}-0.#{platform}.#{version}_#{rel_arch}.deb"
   else
     #for getting latest version of full stack installers
-    Net::HTTP.start('www.getchef.com') do |http|
+    Net::HTTP.start('www.chef.io') do |http|
       Chef::Log.debug("/chef/download?v=#{node['pxe_dust']['chefversion']}&p=#{platform}&pv=#{version}&m=#{rel_arch}")
       response = http.get("/chef/download?v=#{node['pxe_dust']['chefversion']}&p=#{platform}&pv=#{version}&m=#{rel_arch}")
       Chef::Log.debug("Code = #{response.code}")


### PR DESCRIPTION
This commit https://github.com/chef/chef/commit/18b1681a72865811331167c0cffd032f217d0f66 moved the bootstrap template directory, so the cookbook fails with:
```
remote_file[/var/www/pxe_dust/chef-full.erb] (pxe_dust::bootstrap_template line 26) had an error: Net::HTTPServerException: 404 "Not Found"
```
Also updated some of the opscode.com and getchef.com references to chef.io, though they were being redirected anyway.