### PR TITLE
Lazy evaluate the contents of vesamenu.c32

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ you'll get a new menu item to bootstrap into ESXi, with a [kickstart](templates/
 - `node['pxe_dust']['dhcpd_next_server']` defaults to your tftp server `192.168.10.1`
 - `node['pxe_dust']['esxi_iso]` The name of the VMWare ESXi ISO that you'd like to install. The recipe expects it in `/tmp` of the machine that will host the tftp server.
 - `node['pxe_dust']['esxi_rootpasswd']` defaults to `Ubuntu!!`, you can override it here.
+- `node['pxe_dust']['syslinux_default_menu_path']` defaults to path for vesamenu.c32 in syslinux package on Debian & Ubuntu. If you wish to use a different menu system, you can override it here.
 
 # License and Author
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,3 +42,12 @@ default['pxe_dust']['dhcpd_next_server'] = '192.168.10.1'
 
 default['pxe_dust']['esxi_iso'] = 'VMware-VMvisor-Installer-6.0.0.update01-3029758.x86_64.iso'
 default['pxe_dust']['esxi_rootpasswd'] = 'Ubuntu!!'
+
+default['pxe_dust']['syslinux_default_menu_path'] = value_for_platform(
+  ['ubuntu' ] => {
+    'default' => '/usr/lib/syslinux/vesamenu.c32'
+  },
+  ['debian'] => {
+    'default' => '/usr/lib/syslinux/modules/bios/vesamenu.c32'
+  }
+)

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -48,7 +48,7 @@ file "#{node['tftp']['directory']}/vesamenu.c32" do
   owner 'root'
   group 'root'
   mode 0755
-  content ::File.open('/usr/lib/syslinux/vesamenu.c32').read
+  content lazy { ::File.open(node['pxe_dust']['syslinux_default_menu_path']).read }
   action :create
 end
 

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -8,6 +8,10 @@ describe 'pxe_dust::server' do
     it { should exist }
   end
 
+  describe file('/var/lib/tftpboot/vesamenu.c32') do
+    it { should exist }
+  end
+
   describe file('/var/lib/tftpboot/default') do
     it { should exist }
     it { should be_directory }


### PR DESCRIPTION
The contents of vesamenu.c32 are read as part of the server recipe, but at the initial compile the file doesn't exist as the syslinux packages aren't installed yet, so compilation fails. (Chef 12.9.38)

I've added lazy evaluation of the contents as well as an attribute for the path of that file.

```
================================================================================
Recipe Compile Error in /tmp/kitchen/cache/cookbooks/pxe_dust/recipes/server.rb
================================================================================

Errno::ENOENT
-------------
No such file or directory @ rb_sysopen - /usr/lib/syslinux/vesamenu.c32

Cookbook Trace:
---------------
 /tmp/kitchen/cache/cookbooks/pxe_dust/recipes/server.rb:51:in `initialize'
 /tmp/kitchen/cache/cookbooks/pxe_dust/recipes/server.rb:51:in `open'
 /tmp/kitchen/cache/cookbooks/pxe_dust/recipes/server.rb:51:in `block in from_file'
 /tmp/kitchen/cache/cookbooks/pxe_dust/recipes/server.rb:47:in `from_file'

Relevant File Content:
----------------------
/tmp/kitchen/cache/cookbooks/pxe_dust/recipes/server.rb:

44:    mode 0755
45:  end
46:
47:  file "#{node['tftp']['directory']}/vesamenu.c32" do
48:    owner 'root'
49:    group 'root'
50:    mode 0755
51>>   content ::File.open('/usr/lib/syslinux/vesamenu.c32').read
52:    action :create
53:  end
54:
55:  # loop over the other data bag items here
56:  begin
57:    default = node['pxe_dust']['default']
58:    pxe_dust = data_bag('pxe_dust')
59:    default = data_bag_item('pxe_dust', 'default').merge(default)
60:  rescue

Platform:
---------
x86_64-linux
```
